### PR TITLE
fix: add instructions to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-OPENAI_API_KEY="<your-key-here>"
+# OpenAI key retrieved here: https://platform.openai.com/api-keys
+OPENAI_API_KEY=


### PR DESCRIPTION
Align with `.env.example` expectations from https://vercel.com/templates/submit